### PR TITLE
Improve notification e-mails

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -3,6 +3,9 @@ class CommentMailer < ApplicationMailer
   def creation(to, comment)
     @machine = comment.machine
     @comment = comment
-    mail(:to => to,  :subject => t(:mailer_subject_new_comment, :machine => @machine.title))
+    mail(:to => to,
+         :subject => t(:mailer_subject_new_comment,
+                       :machine => @machine.title,
+                       :user => @machine.user.nickname ))
   end
 end

--- a/app/mailers/has_state_mailer.rb
+++ b/app/mailers/has_state_mailer.rb
@@ -5,6 +5,14 @@ class HasStateMailer < ApplicationMailer
     @state_name = @machine.human_state_name
     @updated_at = @machine.state_updated_at
     @change = @machine.state_changes.newest_first.first
-    mail(:to => to,  :subject => t(:mailer_subject_state, :machine => @machine.title))
+    mail(:to => to,
+         :subject => t(:mailer_subject_state,
+                       :machine => @machine.title,
+                       :user => @machine.user.nickname,
+                       # With the current implementation the #try is not
+                       # required (Request and Reimbursement always respond to
+                       # #event), but better stay safe for future classes
+                       # performing "include HasState"
+                       :event => @machine.try(:event).try(:name)))
   end
 end

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -1,11 +1,11 @@
 en:
-  mailer_subject_state: "%{machine} state information"
-  machine_in_state: "%{machine} is in %{state} (%{description}) state since %{date}"
-  visit_machine: "To access the related information, just follow the link below:"
+  mailer_subject_state: "%{machine} state for %{user}"
+  machine_in_state: "%{machine} is %{state} (%{description}) since %{date}"
+  visit_machine: ""
   with_notes_below: "with the following notes:"
 
-  mailer_subject_new_comment: "New comment on %{machine}"
-  new_comment_title_line: "At %{date}, %{user} added the following comment to %{machine}"
+  mailer_subject_new_comment: "Comment by %{user} on %{machine}"
+  new_comment_title_line: "%{date}, %{user} commented %{machine}"
 
   mailer_subject_missing_reimbursement: "Missing reimbursement for %{request}"
   missing_reimbursement_text: "No reimbursement has been created for %{request}. Remember that the reimbursement process can be started using the 'ask for reimbursement' button in the request view."


### PR DESCRIPTION
Get the username in the subject
Condense some of the information

Context:
We've been using this in KDE, and it's been a bit hard for me to get used to the e-mails, I thought this can be a step forward.
One thing I wanted to do but didn't know how to do is to get the event name on the subject.

Feedback more than welcome.