### PR TITLE
Link to the proper event url

### DIFF
--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -9,7 +9,7 @@
       .span6
         = e.attribute :end_date
         = e.attribute :url do
-          = link_to event.url
+          = link_to *([event.url]*2)
     .row-fluid
       .span12
         = e.attribute :description


### PR DESCRIPTION
Without this i have a link that says https://sprints.kde.org/sprint/296 but links to https://reimbursements.kde.org/travel_sponsorships/6 instead of linking to https://sprints.kde.org/sprint/296