### PR TITLE
Normalize nomenclature and adapt

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -6,6 +6,7 @@ class CommentMailer < ApplicationMailer
     mail(:to => to,
          :subject => t(:mailer_subject_new_comment,
                        :machine => @machine.title,
-                       :user => @machine.user.nickname ))
+                       :owner => @machine.user.nickname,
+                       :user => @comment.user.nickname ))
   end
 end

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -4,7 +4,7 @@ en:
   visit_machine: ""
   with_notes_below: "with the following notes:"
 
-  mailer_subject_new_comment: "Comment by %{user} on %{machine}"
+  mailer_subject_new_comment: "Comment on %{owner} %{machine}"
   new_comment_title_line: "%{date}, %{user} commented %{machine}"
 
   mailer_subject_missing_reimbursement: "Missing reimbursement for %{request}"


### PR DESCRIPTION
%{user} was a different between mailer_subject_new_comment and
new_comment_title_line. Adapt and export the value as %{owner} instead, so
%{user} is always the comment author and %{owner} the %{machine} subject.

Fixes issue #24