### PR TITLE
Added the states column in the participants view

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,7 +10,7 @@ class EventsController < InheritedResources::Base
       { label: @event.name, url: event_path(@event) },
       { label: 'participants' }
     ]
-    @requests = @event.travel_sponsorships.includes(:user).select(:user_id).distinct.accessible_by(current_ability)
+    @requests = @event.travel_sponsorships.includes(:user).group(:user_id).accessible_by(current_ability)
   end
 
   protected

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -16,4 +16,19 @@ module EventsHelper
     requests = requests.where(state: state) if state != 'all'
     requests.distinct.pluck('users.email')
   end
+
+  def state_label(state)
+    case state
+    when 'submitted'
+      'label-primary'
+    when 'canceled'
+      'label-danger'
+    when 'incomplete'
+      'label-warning'
+    when 'accepted'
+      'label-success'
+    when 'approved'
+      'label-success'
+    end
+  end
 end

--- a/app/views/events/participants.html.haml
+++ b/app/views/events/participants.html.haml
@@ -6,6 +6,7 @@
       %th #
       %th Nickname
       %th Email
+      %th State
     - @requests.each.with_index(1) do |request,index|
       %tr
         %td #{index}
@@ -13,3 +14,5 @@
           = request.user.nickname
         %td
           = request.user.email
+        %td
+          = content_tag(:span, request.state, class: "label #{state_label(request.state)}")

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -101,6 +101,7 @@ feature 'Events', '' do
     within(:xpath, "(//table[contains(@class, 'table')]//tr)[2]") do
       page.should have_content 'acalamari'
       page.should have_content 'gial.ackbar@rebel-alliance.org'
+      page.should have_content 'incomplete'
     end
   end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -30,4 +30,22 @@ describe EventsHelper, type: :helper do
       expect(users_for_event('accepted')) .to eq([])
     end
   end
+
+  describe '#state_label' do
+    it 'should return primary-label' do
+      expect(state_label('submitted')). to eq 'label-primary'
+    end
+    it 'should return danger-label' do
+      expect(state_label('canceled')). to eq 'label-danger'
+    end
+    it 'should return warning-label' do
+      expect(state_label('incomplete')). to eq 'label-warning'
+    end
+    it 'should return success-label' do
+      expect(state_label('accepted')). to eq 'label-success'
+    end
+    it 'should return success-label' do
+      expect(state_label('approved')). to eq 'label-success'
+    end
+  end
 end


### PR DESCRIPTION
A person can only have a single active request for an event. The State column shows the state of the active request of a user.