### PR TITLE
Set sqlite3, pg and mysql2 versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 gem 'rails', '4.1.10'
 
 # Choose your weapon
-gem 'sqlite3'
-# gem 'pg'
-# gem 'mysql2', '~> 0.3.13'
+gem 'sqlite3', '~> 1.3.13'
+#gem 'pg', '~> 0.21'
+#gem 'mysql2', '~> 0.3.13'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
+    sqlite3 (1.3.13)
     state_machines (0.2.2)
     state_machines-activemodel (0.1.2)
       activemodel (~> 4.1)
@@ -379,7 +379,7 @@ DEPENDENCIES
   shoulda-matchers
   show_for
   simple_form
-  sqlite3
+  sqlite3 (~> 1.3.13)
   state_machines-activerecord
   state_machines-yard
   therubyracer


### PR DESCRIPTION
* Newer releases will not work with Rails 4.1.
* As the versions are not recorded in the `Gemfile.lock`, we need to restrict them in the `Gemfile`.
