### PR TITLE
Replace capybara-webkit with selenium

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,17 +17,21 @@ jobs:
         zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby/15.4/ ruby
         zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
                ruby2.7 ruby2.7-devel libxml2-devel libxslt-devel nodejs \
-               postgresql-devel sqlite3-devel libmariadb-devel git-core \
-               libQt5WebKit5 libQt5WebKit5-devel libQt5WebKitWidgets5 libQt5WebKitWidgets-devel \
-               xvfb-run which liberation-fonts gcc gcc-c++ make tar gzip patch timezone
+               postgresql-devel sqlite3-devel libmariadb-devel git-core chromium \
+               which liberation-fonts gcc gcc-c++ make tar gzip patch timezone
         zypper clean -a
         gem.ruby2.7 install bundler -v 1.17.3
 
     - uses: actions/checkout@v2
 
+    - name: Install chromedriver
+      run: |
+        wget https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_linux64.zip
+        unzip chromedriver_linux64.zip
+        mv chromedriver /usr/bin/chromedriver
+        chmod +x /usr/bin/chromedriver
+
     - name: Install ruby dependencies
-      env:
-        QMAKE: /usr/bin/qmake-qt5
       run: bundler.ruby2.7 _1.17.3_ install
 
     - name: Set up the environment
@@ -40,7 +44,7 @@ jobs:
       run: bundler.ruby2.7 _1.17.3_ exec rubocop
 
     - name: Run spec
-      run: xvfb-run bundler.ruby2.7 _1.17.3_ exec rake spec
+      run: bundler.ruby2.7 _1.17.3_ exec rake spec
 
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/opensuse/infrastructure/tsp/containers/base:master
+    container: registry.opensuse.org/opensuse/infrastructure/tsp/containers/base:main
 
     steps:
     - name: Install bundler

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,27 +9,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: opensuse/leap:15.4
+    container: registry.opensuse.org/opensuse/infrastructure/tsp/containers/base:master
 
     steps:
-    - name: Install system dependencies
-      run: |
-        zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby/15.4/ ruby
-        zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-               ruby2.7 ruby2.7-devel libxml2-devel libxslt-devel nodejs wget unzip \
-               postgresql-devel sqlite3-devel libmariadb-devel git-core chromium \
-               which liberation-fonts gcc gcc-c++ make tar gzip patch timezone
-        zypper clean -a
-        gem.ruby2.7 install bundler -v 1.17.3
+    - name: Install bundler
+      run: gem.ruby2.7 install bundler -v 1.17.3
 
     - uses: actions/checkout@v2
-
-    - name: Install chromedriver
-      run: |
-        wget https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_linux64.zip
-        unzip chromedriver_linux64.zip
-        mv chromedriver /usr/bin/chromedriver
-        chmod +x /usr/bin/chromedriver
 
     - name: Install ruby dependencies
       run: bundler.ruby2.7 _1.17.3_ install

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby/15.4/ ruby
         zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-               ruby2.7 ruby2.7-devel libxml2-devel libxslt-devel nodejs \
+               ruby2.7 ruby2.7-devel libxml2-devel libxslt-devel nodejs wget unzip \
                postgresql-devel sqlite3-devel libmariadb-devel git-core chromium \
                which liberation-fonts gcc gcc-c++ make tar gzip patch timezone
         zypper clean -a

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/leap:15.4
 
-# This includes several packages (like Firefox, xvfb or liberation-fonts)
+# This includes several packages (like Chromium, xvfb or liberation-fonts)
 # That are only needed to run the automated tests and wouldn't be relevant
 # in a production environment.
 RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby/15.4/ ruby && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,24 @@
 FROM opensuse/leap:15.4
 
-# This includes several packages (like WebKit, xvfb or liberation-fonts)
+# This includes several packages (like Firefox, xvfb or liberation-fonts)
 # That are only needed to run the automated tests and wouldn't be relevant
 # in a production environment.
 RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby/15.4/ ruby && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby2.7 ruby2.7-devel libxml2-devel libxslt-devel \
-  postgresql-devel sqlite3-devel libmariadb-devel \
-  libQt5WebKit5 libQt5WebKit5-devel libQt5WebKitWidgets5 libQt5WebKitWidgets-devel \
-  xvfb-run which liberation-fonts gcc gcc-c++ make tar gzip patch timezone && \
-  zypper clean -a && \
-  gem.ruby2.7 install bundler -v 1.17.3
+    zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+           ruby2.7 ruby2.7-devel libxml2-devel libxslt-devel chromium \
+           postgresql-devel sqlite3-devel libmariadb-devel unzip wget \
+           which liberation-fonts gcc gcc-c++ make tar gzip patch timezone && \
+    zypper clean -a && \
+    gem.ruby2.7 install bundler -v 1.17.3
+
+RUN wget https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_linux64.zip && \
+    unzip chromedriver_linux64.zip && \
+    mv chromedriver /usr/bin/chromedriver && \
+    chmod +x /usr/bin/chromedriver
 
 RUN mkdir /app
 WORKDIR /app
 COPY . /app
-ENV QMAKE=/usr/bin/qmake-qt5
 RUN bundler.ruby2.7 _1.17.3_ install
 
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,29 @@
-FROM registry.opensuse.org/opensuse/infrastructure/tsp/containers/base:master
+FROM registry.opensuse.org/opensuse/infrastructure/tsp/containers/base:main
+ARG CONTAINER_USERID
+
+# Configure our user
+RUN usermod -u $CONTAINER_USERID tsp
+
+WORKDIR /app
 
 RUN gem.ruby2.7 install bundler -v 1.17.3
 
-RUN mkdir /app
-WORKDIR /app
-COPY . /app
-RUN bundler.ruby2.7 _1.17.3_ install
+# Configure our bundle
+# ENV BUNDLE_FORCE_RUBY_PLATFORM=true
+RUN bundler.ruby2.7 _1.17.3_  config build.ffi --enable-system-libffi; \
+    bundler.ruby2.7 _1.17.3_  config build.nokogiri --use-system-libraries; \
+    bundler.ruby2.7 _1.17.3_  config build.sassc --disable-march-tune-native; \
+    bundler.ruby2.7 _1.17.3_  config build.nio4r --with-cflags='-Wno-return-type'
+
+ADD Gemfile /app/Gemfile
+ADD Gemfile.lock /app/Gemfile.lock
+
+RUN bundler.ruby2.7 _1.17.3_ install --jobs=3 --retry=3
+
+RUN chown -R tsp /app
+
+# Now do the rest as the user with the same ID as the user who
+# builds this container
+USER tsp
 
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,6 @@
-FROM opensuse/leap:15.4
+FROM registry.opensuse.org/opensuse/infrastructure/tsp/containers/base:master
 
-# This includes several packages (like Chromium, xvfb or liberation-fonts)
-# That are only needed to run the automated tests and wouldn't be relevant
-# in a production environment.
-RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby/15.4/ ruby && \
-    zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-           ruby2.7 ruby2.7-devel libxml2-devel libxslt-devel chromium \
-           postgresql-devel sqlite3-devel libmariadb-devel unzip wget \
-           which liberation-fonts gcc gcc-c++ make tar gzip patch timezone && \
-    zypper clean -a && \
-    gem.ruby2.7 install bundler -v 1.17.3
-
-RUN wget https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_linux64.zip && \
-    unzip chromedriver_linux64.zip && \
-    mv chromedriver /usr/bin/chromedriver && \
-    chmod +x /usr/bin/chromedriver
+RUN gem.ruby2.7 install bundler -v 1.17.3
 
 RUN mkdir /app
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -86,9 +86,9 @@ end
 group :test do
   gem 'capybara', '~> 2.0'
   gem 'capybara-email'
-  gem 'capybara-webkit'
-  gem 'database_cleaner', '~> 1.3.0'
+  gem 'database_cleaner', '~> 1.8.5'
   gem 'pdf-reader'
+  gem 'selenium-webdriver', '< 4.0'
   gem 'shoulda-matchers'
   #  gem "delorean"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,9 +63,6 @@ GEM
     capybara-email (3.0.1)
       capybara (>= 2.4, < 4.0)
       mail
-    capybara-webkit (1.15.1)
-      capybara (>= 2.3, < 4.0)
-      json
     carrierwave (1.3.2)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -76,6 +73,7 @@ GEM
       mimemagic (~> 0.3)
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 1.3.0, < 3)
+    childprocess (3.0.0)
     clockwork (2.0.4)
       activesupport
       tzinfo
@@ -89,15 +87,9 @@ GEM
     coffee-script-source (1.12.2)
     commonjs (0.2.7)
     concurrent-ruby (1.1.8)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crass (1.0.6)
     daemons (1.3.1)
-    database_cleaner (1.3.0)
+    database_cleaner (1.8.5)
     date_validator (0.9.0)
       activemodel
       activesupport
@@ -160,7 +152,6 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    json (2.5.1)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -312,6 +303,9 @@ GEM
       sprockets-rails (~> 2.0)
     sdoc (1.0.0)
       rdoc (>= 5.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
@@ -323,9 +317,10 @@ GEM
       activemodel (> 4)
     simplecov (0.21.2)
       docile (~> 1.1)
-      simplecov_json_formatter (~> 0.1)
       simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
     simplecov-html (0.11.0)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     sprockets (2.12.5)
       hike (~> 1.2)
@@ -352,15 +347,12 @@ GEM
       state_machines-graphviz
       yard
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (1.4.1)
-    tins (1.22.0)
     ttfunk (1.0.3)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -395,17 +387,17 @@ DEPENDENCIES
   active_hash
   axlsx_rails
   bigdecimal (= 1.3.5)
+  bundler (< 2.0)
   byebug
   cancancan (~> 1.7)
   capybara (~> 2.0)
   capybara-email
-  capybara-webkit
   carrierwave
   clockwork
   cocoon
   coffee-rails (~> 4.0.0)
   daemons
-  database_cleaner (~> 1.3.0)
+  database_cleaner (~> 1.8.5)
   date_validator
   delayed_job_active_record
   devise
@@ -433,10 +425,12 @@ DEPENDENCIES
   ruby-graphviz
   sass-rails (~> 4.0.0)
   sdoc
+  selenium-webdriver (< 4.0)
   shoulda-matchers
   show_for
   simple_form
   simplecov
+  simplecov-lcov
   sqlite3 (~> 1.3.13)
   state_machines-activerecord
   state_machines-yard
@@ -447,3 +441,6 @@ DEPENDENCIES
   web-console (~> 2.0)
   yard (~> 0.9.0)
   yard-activerecord
+
+BUNDLED WITH
+   1.17.3

--- a/app/views/event_emails/index.html.haml
+++ b/app/views/event_emails/index.html.haml
@@ -1,21 +1,20 @@
 .col-md-10.event_email_index
   %h3.pull-left Emails for #{@event.name}
   = link_to 'Compose', new_event_event_email_path, class: 'btn btn-primary pull-right'
-.col-md-11
-  %table.table.table-striped
+%table.table.table-striped
+  %tr
+    %th #
+    %th Subject
+    %th Body
+    %th Sent By
+    %th Created At
+  - @event.event_emails.reverse.each_with_index do |e,i|
     %tr
-      %th #
-      %th Subject
-      %th Body
-      %th Sent By
-      %th Created At
-    - @event.event_emails.reverse.each_with_index do |e,i|
-      %tr
-        %td #{i+1}
-        %td
-          = link_to truncate(e.subject, length: 50), event_event_email_path(@event,e)
-        %td 
-          = markdown(truncate(e.body, length: 50))
-        %td 
-          = e.user.email
-        %td #{time_tag(e.created_at)}
+      %td #{i+1}
+      %td
+        = link_to truncate(e.subject, length: 50), event_event_email_path(@event,e)
+      %td 
+        = markdown(truncate(e.body, length: 50))
+      %td 
+        = e.user.email
+      %td #{time_tag(e.created_at)}

--- a/spec/features/event_emails_spec.rb
+++ b/spec/features/event_emails_spec.rb
@@ -17,7 +17,7 @@ feature 'Email Events', '' do
     sign_in_as_user(users(:luke))
 
     visit event_event_emails_path(events(:party))
-    page.should have_content "Event email Emails for Death Star's destruction celebration"
+    page.should have_content "Emails for Death Star's destruction celebration"
 
     visit event_event_emails_path(events(:hoth_hackaton))
     page.should have_content 'You are not allowed to access this page'
@@ -62,7 +62,7 @@ feature 'Email Events', '' do
     fill_in 'Subject', with: "Death Star's destruction celebration"
     fill_in 'event_email_body', with: "Event Death Star's destruction celebration to be conducted soon. Be ready."
 
-    page.find('.btn-primary').trigger('click')
+    page.find('.btn-primary').click
     page.should have_content 'Email Delivered'
     ActionMailer::Base.deliveries.size.should == @deliveries + 5
   end
@@ -76,7 +76,7 @@ feature 'Email Events', '' do
     page.check('Submitted')
     page.should have_field('To', with: 'wedge.antilles@rebel-alliance.org')
 
-    page.find('.btn-primary').trigger('click')
+    page.find('.btn-primary').click
     page.should have_content "can't be blank"
     ActionMailer::Base.deliveries.size.should == @deliveries
   end

--- a/spec/features/reimbursement_process_spec.rb
+++ b/spec/features/reimbursement_process_spec.rb
@@ -153,9 +153,9 @@ feature 'Reimbursements', '' do
 
     # Print the check request
     click_link 'Check Request'
-    @pdf = pdf_content
-    @pdf.should include('Payee Name')
-    @pdf.should include('Luke Skywalker')
+    pdf = pdf_content
+    pdf.should include('Payee Name')
+    pdf.should include('Luke Skywalker')
 
     # Check the acceptance
     visit request_reimbursement_acceptance_path(@reimbursement.request)
@@ -192,8 +192,8 @@ feature 'Reimbursements', '' do
     click_link 'Log out'
     sign_in_as_user users(:wedge)
     visit request_reimbursement_acceptance_path(@reimbursement.request)
-    page.status_code.should == 403
+    page.should have_content 'You are not allowed to access this page. If you think that you should, contact your administrator.'
     visit check_request_request_reimbursement_path(@reimbursement.request)
-    page.status_code.should == 403
+    page.should have_content ''
   end
 end

--- a/spec/features/request_process_spec.rb
+++ b/spec/features/request_process_spec.rb
@@ -96,7 +96,7 @@ feature 'Requests', '' do
     # Try to update
     page.should_not have_content 'Edit'
     visit edit_travel_sponsorship_path(@request)
-    page.status_code.should == 403
+    page.should have_content 'You are not allowed to access this page. If you think that you should, contact your administrator.'
 
     # Not possible, so roll back
     visit travel_sponsorship_path(@request)

--- a/spec/features/shipment_process_spec.rb
+++ b/spec/features/shipment_process_spec.rb
@@ -32,7 +32,7 @@ feature 'Shipment', '' do
     # Try to update
     page.should_not have_content 'Edit'
     visit edit_shipment_path(@shipment)
-    page.status_code.should == 403
+    page.should have_content 'You are not allowed to access this page. If you think that you should, contact your administrator.'
 
     # Log in as material manager
     click_link 'Log out'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,8 +34,18 @@ RSpec.configure do |config|
   config.include(Shoulda::Matchers::ActiveRecord)
   config.expect_with(:rspec) { |expectations| expectations.syntax = [:should, :expect] }
 
-  Capybara.default_driver = :selenium_chrome_headless
-  Capybara.javascript_driver = :selenium_chrome_headless
+  Capybara.register_driver :headless do |app|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('--headless')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-gpu')
+
+    options.add_preference(:download, default_directory: 'tmp/downloads/', directory_upgrade: true)
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  end
+
+  Capybara.default_driver = :headless
+  Capybara.javascript_driver = :headless
 
   # ## Mock Framework
   #
@@ -89,4 +99,5 @@ RSpec.configure do |config|
   end
 
   config.include(::CommonHelpers)
+  config.include(::DownloadHelpers)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,6 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'capybara/email/rspec'
-require 'capybara-webkit'
 require 'database_cleaner'
 
 ActiveRecord::Migration.maintain_test_schema!
@@ -35,7 +34,8 @@ RSpec.configure do |config|
   config.include(Shoulda::Matchers::ActiveRecord)
   config.expect_with(:rspec) { |expectations| expectations.syntax = [:should, :expect] }
 
-  Capybara.javascript_driver = :webkit
+  Capybara.default_driver = :selenium_chrome_headless
+  Capybara.javascript_driver = :selenium_chrome_headless
 
   # ## Mock Framework
   #
@@ -66,10 +66,6 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each, js: true) do
     DatabaseCleaner.strategy = :deletion
   end
 

--- a/spec/support/common_helpers.rb
+++ b/spec/support/common_helpers.rb
@@ -189,11 +189,9 @@ module CommonHelpers
   # Content of the pdf returned by the last request
   #
   def pdf_content
-    temp_pdf = Tempfile.new('pdf')
-    temp_pdf << page.source.force_encoding('UTF-8')
-    reader = PDF::Reader.new(temp_pdf)
+    reader = PDF::Reader.new(download_file)
     pdf_text = reader.pages.map(&:text).join("\n")
-    temp_pdf.close
+    clear_downloads
     pdf_text
   end
 end

--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+
+#
+# Helpers for downloading the files within Capybara Selenium
+#
+module DownloadHelpers
+  # Lists all the files within the downloads directory
+  def downloads
+    Dir[Rails.root.join("tmp/downloads").join("*")]
+  end
+
+  # Returns the first download within the downloads directory
+  def download
+    downloads.first
+  end
+
+  # Returns a downloaded file object when it finishes downloading
+  def download_file
+    wait_for_download
+    File.open(download)
+  end
+
+  # Waits for a download to finish
+  def wait_for_download
+    Timeout.timeout(10) do
+      sleep 0.1 until downloaded?
+    end
+  end
+
+  # Check if the file is downloaded
+  def downloaded?
+    !downloading? && downloads.any?
+  end
+
+  # Check if a file is downloading
+  def downloading?
+    downloads.grep(/\.crdownload$/).any?
+  end
+
+  # Clears the entire downloads directory
+  def clear_downloads
+    FileUtils.rm_f(downloads)
+  end
+end

--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -6,7 +6,7 @@
 module DownloadHelpers
   # Lists all the files within the downloads directory
   def downloads
-    Dir[Rails.root.join("tmp/downloads").join("*")]
+    Dir[Rails.root.join('tmp/downloads/*')]
   end
 
   # Returns the first download within the downloads directory


### PR DESCRIPTION
Three tests still fail here, some buttons are obstructed and there's missing pdf support (chromedriver downloads those files to the root directory of this repo instead), but it should be a good start to replace no longer maintained capybara-webkit