### PR TITLE
Support Unix socket listener

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,9 +7,8 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port        ENV.fetch("PORT") { 3000 }
+# Specifies the socket Puma will listen on, can be tcp:// or unix://, defaults to localhost:3000
+bind ENV.fetch("BIND") { "tcp://[::1]:#{ ENV.fetch('PORT', 3000) }" }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
This removes the "port" directive in favor of "bind", and for consistency also exchanges the "PORT" variable with "BIND". This allows users to override the default TCP listener with not only a different port, but also optionally with a Unix socket, by setting a "BIND" environment variable, without having to modify puma.rb.

The default listener is additionally changed to localhost to improve security in installations without customization.