### PR TITLE
Enable pg by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'responders'
 
 # Choose your weapon
 gem 'sqlite3', '~> 1.6.1'
-# gem 'pg', '~> 0.21'
+gem 'pg', '~> 0.21'
 # gem 'mysql2', '~> 0.4.10'
 
 # This can only be removed with Rails 7.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
+    pg (0.21.0)
     polyamorous (2.3.0)
       activerecord (>= 5.0)
     prawn (0.13.2)
@@ -429,6 +430,7 @@ DEPENDENCIES
   mail (< 2.8.0)
   mini_racer
   pdf-reader
+  pg (~> 0.21)
   prawn (~> 0.13.0)
   prawn_rails
   psych (< 4.0)


### PR DESCRIPTION
Managing changes in a file which is tracked by Git causes conflicts with configuration management when the repository needs to get updated. As there is no configuration scheme for this so far, enable it by default instead.